### PR TITLE
Don't send empty TWCC feedback packets

### DIFF
--- a/pkg/twcc/twcc.go
+++ b/pkg/twcc/twcc.go
@@ -70,6 +70,9 @@ func insertSorted(list []pktInfo, element pktInfo) []pktInfo {
 
 // BuildFeedbackPacket creates a new RTCP packet containing a TWCC feedback report.
 func (r *Recorder) BuildFeedbackPacket() []rtcp.Packet {
+	if len(r.receivedPackets) == 0 {
+		return nil
+	}
 	feedback := newFeedback(r.senderSSRC, r.mediaSSRC, r.fbPktCnt)
 	r.fbPktCnt++
 	if len(r.receivedPackets) < 2 {


### PR DESCRIPTION
Instead, send nothing. This fixes a warning message that would appear in the Chrome debug logs (verified in testing). Details in
https://wonderinventions.slack.com/archives/C01EHMKKCJD/p1658154181871659